### PR TITLE
fixed a problem with Japanese input being sent during IME input conversion

### DIFF
--- a/lib/playground/user-interface/src/components/chat-ui/chat-ui-input-panel.tsx
+++ b/lib/playground/user-interface/src/components/chat-ui/chat-ui-input-panel.tsx
@@ -29,6 +29,7 @@ export interface ChatUIInputPanelProps {
 export default function ChatUIInputPanel(props: ChatUIInputPanelProps) {
   const [inputText, setInputText] = useState("");
   const [fileDialogVisible, setFileDialogVisible] = useState(false);
+  const [isComposing, setIsComposing] = useState(false);
 
   useEffect(() => {
     const onWindowScroll = () => {
@@ -88,7 +89,7 @@ export default function ChatUIInputPanel(props: ChatUIInputPanelProps) {
   const onTextareaKeyDown = (
     event: React.KeyboardEvent<HTMLTextAreaElement>,
   ) => {
-    if (!props.running && event.key === "Enter" && !event.shiftKey) {
+    if (!props.running && event.key === "Enter" && !event.shiftKey && !isComposing) {
       event.preventDefault();
       onSendMessage();
     }
@@ -125,6 +126,8 @@ export default function ChatUIInputPanel(props: ChatUIInputPanelProps) {
             onKeyDown={onTextareaKeyDown}
             value={inputText}
             placeholder={props.inputPlaceholderText ?? "Send a message"}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
           />
           <div style={{ marginLeft: "8px" }}>
             <Button


### PR DESCRIPTION
When entering Japanese, users must perform a Kanji conversion operation. When the Enter key is pressed to select a candidate for Kanji conversion, it is also submitted even in the middle of a sentence. To avoid this problem, a state variable called isComposing is defined in the useState hook, and the state variable is changed in the onCompositionStart/End event handler. When this state is false, the state variable is included in the judgment statement of the onTextareaKeyDown event to prevent text input from being submitted in progress. This allows us to distinguish between a decision transmission and a decision to convert.
